### PR TITLE
Feature/27 inspizzz top bar logo too big

### DIFF
--- a/app/components/TopBar/index.jsx
+++ b/app/components/TopBar/index.jsx
@@ -24,7 +24,7 @@ export function TopBar() {
 
 			<div className="flex gap-4 justify-center items-center">
 				<Link href="https://www.sec-ridge.com/" target="_blank" className="">
-					<Image src="/images/EX-removebg-preview.png" className="h-full w-full object-fill" width={100} height={100} alt="not found" />
+					<Image src="/images/EX-removebg-preview.png" className="h-8 w-full object-fill" width={100} height={100} alt="not found" />
 				</Link>
 			</div>
 


### PR DESCRIPTION
Checked with production using inspect, these changes should resolve the top bar logo being too big